### PR TITLE
Format blog sidebar similarly to doc sidebar

### DIFF
--- a/static/css/article.css
+++ b/static/css/article.css
@@ -10,7 +10,7 @@
 
 .article .article-infos ul {
     list-style: none;
-    margin: 0;
+    margin: 0 0 12px 0;
     padding: 0;
 }
 
@@ -70,7 +70,7 @@ a.nav-link .title {
     font-weight: bold;
 }
 
-/* Style the list */
+/* Style the category list */
 ul.breadcrumb {
     display: inline-block;
     padding: 4px 10px;
@@ -106,12 +106,12 @@ ul.breadcrumb li a:hover {
     text-decoration: underline;
 }
 
+/* Style the tag list */
 ul.tag-list {
     display: inline-block;
     padding: 4px 0px;
     list-style: none;
     margin-top: 12px;
-    margin-bottom: 12px;
 }
 
 ul.tag-list li {
@@ -142,6 +142,7 @@ ul.tag-list li.selected a {
     text-decoration: none;
 }
 
+/* Navigation links on sidebar */
 .doc-sidebar a {
     float: none;
     display: block;
@@ -156,7 +157,6 @@ ul.tag-list li.selected a {
     color: var(--color-primary);
 }
 
-/* */
 ul.nav-tree-items {
     list-style: none;
     padding: 0px;

--- a/template/blog_page.hbs
+++ b/template/blog_page.hbs
@@ -1,39 +1,38 @@
 {{> common_header this }}
 
 <div class="doc-container">
-    <div class="doc-tagbar">
-        {{#if tags}}
-        Tags:
-        <ul class="tag-list">
-            {{#each tags}}
-            <li {{#if selected}}class="selected" {{/if}}><a class="tag-link"
-                    href="/{{../meta.section}}/tags/{{name}}">{{name}}</a></li>
-            {{/each}}
-        </ul>
-        {{/if}}
-    </div>
-</div>
-
-<div class="doc-container">
     <div class="doc-sidebar" id="localSidebar">
 
         {{{ sidebar }}}
 
         <div class="feed-links">
-            <a href="/{{meta.section}}/atom.xml"><img src="/static/img/rss.png" alt="RSS feed" class="icon-24"></a>
+            <a href="/{{meta.section}}/atom.xml"><img src="/static/img/rss.png" alt="Atom feed" class="icon-24"></a>
         </div>
 
     </div>
 
     <div class="doc-contents">
 
+        {{#if tags}}
+        <nav class="doc-tagbar">
+            Tags:
+            <ul class="tag-list">
+                {{#each tags}}
+                <li {{#if selected}}class="selected"{{/if}}>
+                    <a class="tag-link" href="/{{../meta.section}}/tags/{{name}}">{{name}}</a>
+                </li>
+                {{/each}}
+            </ul>
+        </nav>
+        {{/if}}
+
         {{{ contents }}}
 
         {{> unit }}
 
-        <div class="nav-link-container">
-            {{ #if meta.prev }}
-            <a href="{{ meta.prev.url }}" class="nav-link">
+        <nav class="nav-link-container">
+            {{#if meta.prev}}
+            <a href="{{meta.prev.url}}" class="nav-link">
                 <div class="direction">
                     Prev
                 </div>
@@ -41,9 +40,9 @@
                     &laquo;&nbsp;{{meta.prev.title}}
                 </div>
             </a>
-            {{ /if }}
-            {{ #if meta.next }}
-            <a href="{{ meta.next.url }}" class="nav-link next">
+            {{/if}}
+            {{#if meta.next}}
+            <a href="{{meta.next.url}}" class="nav-link next">
                 <div class="direction">
                     Next
                 </div>
@@ -51,8 +50,8 @@
                     {{meta.next.title}}&nbsp;&raquo;
                 </div>
             </a>
-            {{ /if }}
-        </div>
+            {{/if}}
+        </nav>
     </div>
 
 </div>

--- a/template/blog_post.hbs
+++ b/template/blog_post.hbs
@@ -1,4 +1,7 @@
 <div class="article">
+    <div>
+        <h1>{{title}}</h1>
+    </div>
     <div class="article-infos">
         <ul>
             {{#with (lookup globals.authors meta.author)}}
@@ -8,9 +11,15 @@
                 {{/if}}
                 <b>{{name}}</b>
             </li>
-            <li><i role="img" aria-label="tagged as" class="icon-ui icon-ui-folder"></i> <b>{{#each ../meta.tags}}<a
-                        href="/{{ ../../meta.section }}/tags/{{ this }}">{{ this }}</a> {{/each}} </b></li>
-            <li><i role="img" aria-label="dated" class="icon-ui icon-ui-clock"></i> <b>{{ ../meta.date }}</b></li>
+            <li>
+                <i role="img" aria-label="tagged as" class="icon-ui icon-ui-folder"></i>
+                <b>
+                {{#each ../meta.tags}}
+                    <a href="/{{ ../../meta.section }}/tags/{{ this }}">{{this}}</a>
+                {{/each}}
+                </b>
+            </li>
+            <li><i role="img" aria-label="dated" class="icon-ui icon-ui-clock"></i> <b>{{../meta.date}}</b></li>
             {{#if url}}<li><a href="{{ url }}"><i aria-label="personal website" class="icon-ui icon-ui-link"></i></a></li>{{/if}}
             {{#if twitter_url}}<li><a href="{{ twitter_url }}"><i aria-label="X profile" class="icon-ui icon-ui-x-twitter"></i></a></li>{{/if}}
             {{#if github_url}}<li><a href="{{ github_url }}"><i aria-label="GitHub profile" class="icon-ui icon-ui-github-alt"></i></a></li>{{/if}}
@@ -19,9 +28,9 @@
     </div>
     <div>
         {{#if is_list_view}}
-        <h1><a href="{{ meta.url }}">{{ title }}</a></h1>
+        <h1><a href="{{ meta.url }}">{{title}}</a></h1>
         {{else}}
-        <h1>{{ title }}</h1>
+        <h1>{{title}}</h1>
         {{/if}}
     </div>
     <div>

--- a/template/blog_post.hbs
+++ b/template/blog_post.hbs
@@ -1,6 +1,10 @@
 <div class="article">
     <div>
+        {{#if is_list_view}}
+        <h1><a href="{{ meta.url }}">{{title}}</a></h1>
+        {{else}}
         <h1>{{title}}</h1>
+        {{/if}}
     </div>
     <div class="article-infos">
         <ul>
@@ -25,13 +29,6 @@
             {{#if github_url}}<li><a href="{{ github_url }}"><i aria-label="GitHub profile" class="icon-ui icon-ui-github-alt"></i></a></li>{{/if}}
             {{/with}}
         </ul>
-    </div>
-    <div>
-        {{#if is_list_view}}
-        <h1><a href="{{ meta.url }}">{{title}}</a></h1>
-        {{else}}
-        <h1>{{title}}</h1>
-        {{/if}}
     </div>
     <div>
         {{{ contents }}}

--- a/template/blog_sidebar.hbs
+++ b/template/blog_sidebar.hbs
@@ -1,3 +1,9 @@
-<h2>{{ title }}</h2>
-
-{{#each links}}<a href="{{ url }}" {{#if selected}}class="selected" {{/if}}>{{ title }}</a>{{/each}}
+<nav class="nav-tree">
+    <ul class="nav-tree-items level-0">
+        <li class="nav-tree-category selected"><a href="{{root_url}}" class="nav-tree-category selected">{{title}}</a>
+            <ul class="nav-tree-items level-1">
+                {{#each links}}<li><a href="{{url}}" class="nav-tree-item {{#if selected}}selected{{/if}}">{{title}}</a></li>{{/each}}
+            </ul>
+        </li>
+    </ul>
+</nav>


### PR DESCRIPTION
Also moves blog article info underneath the titles and adds <nav> tags to a few more link sections (blog tags, article prev-next buttons, blog sidebar).